### PR TITLE
Fix: Use output path instead of input path in ExcelWriter

### DIFF
--- a/src/AITestAnalyzer/Program.cs
+++ b/src/AITestAnalyzer/Program.cs
@@ -32,8 +32,8 @@ namespace AITestAnalyzer
             string outputDir = ExcelWriter.CreateOutputFolder();
             string outputPath = ExcelWriter.PrepareOutputFile(appConfig.ExcelPath, outputDir);
 
-            var excelWriter = new ExcelWriter(appConfig.ExcelPath);
-            excelWriter.RenameOriginalSheet();  // ← ADD THIS LINE
+            var excelWriter = new ExcelWriter(outputPath);// Need to use outputPath here
+            excelWriter.RenameOriginalSheet();  
             excelWriter.AddAnalysisColumnHeader();
             Console.WriteLine();
 


### PR DESCRIPTION
- Changed ExcelWriter initialization to use outputPath instead of appConfig.ExcelPath
- This prevents modifications to the input Excel file
- Input file now remains unchanged during analysis
- Output file correctly receives all analysis sheets

Fixes #2