### PR TITLE
Fix: Use FolderPath instead of FilePath in batch mode

### DIFF
--- a/src/AITestAnalyzer/Program.cs
+++ b/src/AITestAnalyzer/Program.cs
@@ -275,7 +275,7 @@ namespace AITestAnalyzer
         // ============================================================
         static async Task RunBatchMode(Configuration appConfig, PromptConfig promptConfig, SelectionResult selection)
         {
-            string folderPath = selection.FilePath;
+            string folderPath = selection.FolderPath;
             int worksheetIndex = selection.SheetIndex;
             int testLimit = selection.TestLimit;
             bool useCache = true;


### PR DESCRIPTION
- RunBatchMode was reading selection.FilePath (empty for batch)
- Changed to selection.FolderPath which FileSelector correctly sets
- Batch processing now receives the configured folder path

Fixes #4