### PR TITLE
Fix #7: Preserve coverage data in cache (COMPLETE)

### DIFF
--- a/src/AITestAnalyzer/Batchprocessor .cs
+++ b/src/AITestAnalyzer/Batchprocessor .cs
@@ -201,8 +201,8 @@ namespace AITestAnalyzer
                             {
                                 // CACHE HIT
                                 analysisResult = cachedResult!.AnalysisResult;
-                                quality = analysisResult;  // Map for consistency
-                                coverage = "None";
+                                quality = cachedResult.Quality;      // NEW
+                                coverage = cachedResult.Coverage;    // NEW
                                 tokens = 0;
                                 cacheHits++;
                             }
@@ -211,7 +211,7 @@ namespace AITestAnalyzer
                                 // CACHE MISS - Call API
                                 (quality, coverage, tokens) = await aiAnalyzer.AnalyzeTestCase(testCase, requirements);
                                 analysisResult = quality;  // Map quality to result
-                                cache.AddToCache(testCase.TestId, hash, analysisResult, tokens);
+                                cache.AddToCache(testCase.TestId, hash, quality, coverage, tokens);
                                 apiCalls++;
                                 await Task.Delay(1000); // Rate limiting
                             }

--- a/src/AITestAnalyzer/Program.cs
+++ b/src/AITestAnalyzer/Program.cs
@@ -461,8 +461,8 @@ namespace AITestAnalyzer
                     {
                         // Cache hit - use cached result
                         result = cachedResult!.AnalysisResult;
-                        quality = result;  // For now, treat cached result as quality
-                        coverage = "None"; // No coverage in cache yet
+                        quality = cachedResult.Quality;     // NEW: Get from cache
+                        coverage = cachedResult.Coverage;   // NEW: Get from cache
                         tokens = 0;
                         cacheHits++;
                     }
@@ -471,7 +471,7 @@ namespace AITestAnalyzer
                         // Cache miss - call AI
                         (quality, coverage, tokens) = await aiAnalyzer.AnalyzeTestCase(testCase, requirements);
                         result = quality;  // Store quality as result for now
-                        cache.AddToCache(testCase.TestId, hash, result, tokens);
+                        cache.AddToCache(testCase.TestId, hash, quality, coverage, tokens);
                         apiCalls++;
                         await Task.Delay(1000);
                     }

--- a/src/AITestAnalyzer/TestCaseCache.cs
+++ b/src/AITestAnalyzer/TestCaseCache.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;  // ADD THIS LINE
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -11,7 +12,9 @@ namespace AITestAnalyzer
     {
         public string TestId { get; set; } = "";
         public string Hash { get; set; } = "";
-        public string AnalysisResult { get; set; } = "";
+        public string AnalysisResult { get; set; } = "";  // Keep for backward compatibility
+        public string Quality { get; set; } = "";          // NEW: Quality feedback
+        public string Coverage { get; set; } = "";         // NEW: Coverage info
         public int Tokens { get; set; }
         public DateTime CachedAt { get; set; }
     }
@@ -33,6 +36,9 @@ namespace AITestAnalyzer
             _cacheFilePath = Path.Combine(cacheDirectory, "test_analysis_cache.json");
             _cache = new Dictionary<string, CachedResult>(); // Initialize before LoadCache
             LoadCache();
+            // Check if migration is needed
+            MigrateCacheIfNeeded();
+            SaveCache();
         }
 
         // Load cache from disk
@@ -72,6 +78,22 @@ namespace AITestAnalyzer
             {
                 _cache = new Dictionary<string, CachedResult>();
             }
+        }
+
+        // Migrate old cache entries to new format
+        private void MigrateCacheIfNeeded()
+        {
+            int migrated = 0;
+            foreach (var entry in _cache.Values)
+            {
+                if (string.IsNullOrEmpty(entry.Quality) && !string.IsNullOrEmpty(entry.AnalysisResult))
+                {
+                    entry.Quality = entry.AnalysisResult;
+                    entry.Coverage = "None";
+                    migrated++;
+                }
+            }
+            Console.WriteLine($"✅ Migrated {migrated} entries");
         }
 
         // Save cache to disk
@@ -166,13 +188,15 @@ namespace AITestAnalyzer
         }
 
         // Add result to cache
-        public void AddToCache(string testId, string hash, string analysisResult, int tokens)
+        public void AddToCache(string testId, string hash, string quality, string coverage, int tokens)
         {
             _cache[hash] = new CachedResult
             {
                 TestId = testId,
                 Hash = hash,
-                AnalysisResult = analysisResult,
+                AnalysisResult = quality,  // Keep for backward compatibility with old cache
+                Quality = quality,          // NEW
+                Coverage = coverage,        // NEW
                 Tokens = tokens,
                 CachedAt = DateTime.Now
             };


### PR DESCRIPTION
PROBLEM:
Cache hits always returned coverage='None' because quality and coverage were not stored separately in the cache structure.

SOLUTION:
1. Updated CachedResult class with separate Quality and Coverage fields
2. Modified AddToCache() to store both fields independently
3. Updated cache read logic in Program.cs and BatchProcessor.cs
4. Added automatic migration for old cache format (sets Coverage='None')

TESTING:
- New cache entries correctly preserve both quality AND coverage
- Second run with fresh cache shows 100% cache hits with coverage intact
- Old cache entries show Coverage='None' (correct - analyzed pre-coverage)

FILES MODIFIED:
- TestCaseCache.cs: Updated structure and migration logic
- Program.cs: Updated cache read/write to use Quality + Coverage
- BatchProcessor.cs: Updated cache read/write to use Quality + Coverage

RESULT:
Coverage column now persists correctly across runs. Users with old cache can run --clear-cache to rebuild with coverage tracking.