### PR TITLE
fix: Normalize path in RequirementCache to prevent cache misses on re…

### DIFF
--- a/src/AITestAnalyzer/RequirementCache.cs
+++ b/src/AITestAnalyzer/RequirementCache.cs
@@ -81,7 +81,8 @@ namespace AITestAnalyzer
         {
             // Use file path + last modified date as key
             var fileInfo = new FileInfo(documentPath);
-            string combined = $"{documentPath}_{fileInfo.LastWriteTime:yyyyMMddHHmmss}";
+            string normalizedPath = fileInfo.FullName.ToLower(); // ← always absolute, case-insensitive
+            string combined = $"{normalizedPath}_{fileInfo.LastWriteTime:yyyyMMddHHmmss}";
 
             using (var md5 = System.Security.Cryptography.MD5.Create())
             {


### PR DESCRIPTION
…peat runs

GenerateCacheKey now uses FileInfo.FullName (absolute path, lowercase) instead of raw documentPath string. Fixes cache always missing on second run.

Closes #11