### PR TITLE
Fix CB-2: Move hardcoded cost per token to PromptConfig.json

### DIFF
--- a/src/AITestAnalyzer/Batchprocessor .cs
+++ b/src/AITestAnalyzer/Batchprocessor .cs
@@ -15,6 +15,7 @@ namespace AITestAnalyzer
         private readonly Configuration _config;
         private readonly PromptConfig _promptConfig;
         private const int CACHE_MAX_AGE_DAYS = 30;
+        private const int EstimatedTokensPerCachedTest = 150;
 
         public BatchProcessor(Configuration config, PromptConfig promptConfig)
         {
@@ -98,7 +99,7 @@ namespace AITestAnalyzer
 
                 // Initialize components
                 var excelReader = new ExcelReader(inputPath, worksheetIndex);
-                var excelWriter = new ExcelWriter(outputPath, worksheetIndex);
+                var excelWriter = new ExcelWriter(outputPath, _promptConfig, worksheetIndex);
                 var aiAnalyzer = new AIAnalyzer(_config, _promptConfig);
 
                 var reqCache = new RequirementCache();
@@ -290,7 +291,7 @@ namespace AITestAnalyzer
                 result.IssueTests = results.Count(r => r.Result != "GOOD" && !r.Result.StartsWith("ERROR:"));
                 result.ErrorTests = results.Count(r => r.Result.StartsWith("ERROR:"));
                 result.TotalTokens = results.Sum(r => r.Tokens);
-                result.TotalCost = result.TotalTokens * 0.00000015;
+                result.TotalCost = result.TotalTokens * _promptConfig.CostPerToken;
                 result.TimeTaken = (endTime - fileStartTime).TotalSeconds;
                 result.CacheHits = cacheHits;
                 result.ApiCalls = apiCalls;
@@ -530,8 +531,8 @@ namespace AITestAnalyzer
 
                 if (totalCacheHits > 0)
                 {
-                    int savedTokens = totalCacheHits * 150; // Estimated
-                    double savedCost = savedTokens * 0.00000015;
+                    int savedTokens = totalCacheHits * EstimatedTokensPerCachedTest; // Estimated
+                    double savedCost = savedTokens * _promptConfig.CostPerToken;
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.WriteLine($"   💰 Tokens saved:      ~{savedTokens:N0}");
                     Console.WriteLine($"   💵 Cost saved:        ~${savedCost:F6}");

--- a/src/AITestAnalyzer/ExcelWriter.cs
+++ b/src/AITestAnalyzer/ExcelWriter.cs
@@ -12,10 +12,12 @@ namespace AITestAnalyzer
     {
         private readonly string _outputPath;
         private readonly int _worksheetIndex;
+        private readonly PromptConfig _promptConfig;
 
-        public ExcelWriter(string outputPath, int worksheetIndex = 0)
+        public ExcelWriter(string outputPath, PromptConfig promptConfig, int worksheetIndex = 0)
         {
             _outputPath = outputPath;
+            _promptConfig = promptConfig;
             _worksheetIndex = worksheetIndex;
         }
 
@@ -430,7 +432,7 @@ namespace AITestAnalyzer
                     int issueTests = results.Count(r => r.Result != "GOOD" && !r.Result.StartsWith("ERROR:"));
                     int errorTests = results.Count(r => r.Result.StartsWith("ERROR:"));
                     int totalTokens = results.Sum(r => r.Tokens);
-                    double totalCost = totalTokens * 0.00000015;
+                    double totalCost = totalTokens * _promptConfig.CostPerToken;
                     int avgTokens = totalTests > 0 ? totalTokens / totalTests : 0;
                     double timeTaken = (endTime - startTime).TotalSeconds;
                     double qualityScore = totalTests > 0 ? (goodTests * 100.0 / totalTests) : 0;
@@ -968,7 +970,7 @@ namespace AITestAnalyzer
                     row++;
 
                     int apiCalls = results.Count - cacheHits;
-                    double estimatedCost = totalTokens * 0.00000015; // GPT-4o-mini rate
+                    double estimatedCost = totalTokens * _promptConfig.CostPerToken; // GPT-4o-mini rate
 
                     var perfData = new[]
                     {

--- a/src/AITestAnalyzer/Program.cs
+++ b/src/AITestAnalyzer/Program.cs
@@ -364,7 +364,7 @@ namespace AITestAnalyzer
             string outputDir = ExcelWriter.CreateOutputFolder();
             string outputPath = ExcelWriter.PrepareOutputFile(excelPath, outputDir);
 
-            var excelWriter = new ExcelWriter(outputPath, worksheetIndex);
+            var excelWriter = new ExcelWriter(outputPath, promptConfig, worksheetIndex);
             excelWriter.RenameOriginalSheet();
             excelWriter.AddAnalysisColumnHeader(analysisMode);  // ADD MODE PARAMETER
             Console.WriteLine();
@@ -571,7 +571,7 @@ namespace AITestAnalyzer
 
             // Display summary
             Console.WriteLine();
-            SummaryDisplay.Display(results, startTime, endTime, outputPath, cacheHits, apiCalls, useCache, analysisMode);
+            SummaryDisplay.Display(results, startTime, endTime, outputPath, cacheHits, apiCalls, useCache, promptConfig, analysisMode);
 
             Console.WriteLine();
             WriteInfo("Press any key to exit...");
@@ -684,7 +684,8 @@ namespace AITestAnalyzer
                 Model = configBuilder["Model"] ?? "gpt-4o-mini",
                 Temperature = double.Parse(configBuilder["Temperature"] ?? "0.2"),
                 SystemMessage = configBuilder["SystemMessage"] ?? "You are an expert QA analyzer.",
-                UserTemplate = configBuilder["UserTemplate"] ?? "Analyze: {Scenario}"
+                UserTemplate = configBuilder["UserTemplate"] ?? "Analyze: {Scenario}",
+                CostPerToken = double.Parse(configBuilder["CostPerToken"] ?? "0.00000015")
             };
 
             WriteSuccess($"Model: {promptConfig.Model}");

--- a/src/AITestAnalyzer/PromptConfig.cs
+++ b/src/AITestAnalyzer/PromptConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace AITestAnalyzer
+namespace AITestAnalyzer
 {
     public class PromptConfig
     {
@@ -7,5 +7,6 @@
         public double Temperature { get; set; }
         public string SystemMessage { get; set; } = "";
         public string UserTemplate { get; set; } = "";
+        public double CostPerToken { get; set; }
     }
 }

--- a/src/AITestAnalyzer/PromptConfig.json
+++ b/src/AITestAnalyzer/PromptConfig.json
@@ -2,6 +2,7 @@
   "MaxTokens": 250,
   "Model": "gpt-4o-mini",
   "Temperature": 0.2,
+  "CostPerToken": 0.00000015,
   "SystemMessage": "You are an expert QA analyst. Provide CONCISE, tweet-style feedback (under 280 chars). Be direct and actionable.",
   "UserTemplate": "{Requirements}\n\nTEST CASE:\nFeature: {Feature}\nScenario: {Scenario}\nSteps: {Steps}\nExpected: {ExpectedResult}\n\nProvide BRIEF feedback:\nQuality: [ONE sentence max - either 'GOOD' or specific issue]\nCoverage: [Comma-separated requirement topics only]"
 }

--- a/src/AITestAnalyzer/SummaryDisplay.cs
+++ b/src/AITestAnalyzer/SummaryDisplay.cs
@@ -7,6 +7,8 @@ namespace AITestAnalyzer
 {
     public class SummaryDisplay
     {
+        private const int EstimatedTokensPerCachedTest = 150; // Used to estimate cache savings
+
         /// <summary>
         /// Displays comprehensive analysis summary to console with color-coded statistics and cache performance metrics
         /// </summary>
@@ -55,12 +57,12 @@ namespace AITestAnalyzer
         /// - Cache disabled (--no-cache) → Shows warning instead of cache section
         /// </remarks>
         public static void Display(List<(string TestId, string Result, int Tokens, string Coverage)> results,
-                                  DateTime startTime, DateTime endTime, string outputPath, int cacheHits, int apiCalls, bool cacheEnabled, string analysisMode = "QA")
+                                  DateTime startTime, DateTime endTime, string outputPath, int cacheHits, int apiCalls, bool cacheEnabled, PromptConfig promptConfig, string analysisMode = "QA")
         {
             int goodTests = results.Count(r => r.Result.StartsWith("GOOD", StringComparison.OrdinalIgnoreCase));
             int issueTests = results.Count - goodTests;
             int totalTokens = results.Sum(r => r.Tokens);
-            double totalCost = totalTokens * 0.00000015;
+            double totalCost = totalTokens * promptConfig.CostPerToken;
             int avgTokens = results.Count > 0 ? totalTokens / results.Count : 0;
             var duration = (endTime - startTime).TotalSeconds;
 
@@ -95,9 +97,9 @@ namespace AITestAnalyzer
                 if (cacheHits > 0)
                 {
                     // Calculate savings (approximate)
-                    int avgTokensPerTest = 150; // Estimated average
+                    int avgTokensPerTest = EstimatedTokensPerCachedTest; // Estimated average
                     int savedTokens = cacheHits * avgTokensPerTest;
-                    double savedCost = savedTokens * 0.000000150; // GPT-4o-mini cost per token
+                    double savedCost = savedTokens * promptConfig.CostPerToken;
 
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.Write("💰 ");


### PR DESCRIPTION
- Added CostPerToken property to PromptConfig.cs
- Added CostPerToken: 0.00000015 to PromptConfig.json
- Replaced 7 hardcoded cost values across SummaryDisplay, BatchProcessor, ExcelWriter
- Added EstimatedTokensPerCachedTest constant to SummaryDisplay and BatchProcessor
- ExcelWriter constructor now accepts promptConfig parameter

Fixes #15