### PR TITLE
fix(CB-5): Add LRU eviction to prevent unbounded cache growth

### DIFF
--- a/src/AITestAnalyzer/RequirementCache.cs
+++ b/src/AITestAnalyzer/RequirementCache.cs
@@ -11,6 +11,7 @@ namespace AITestAnalyzer
         private readonly string _cacheFolder = "cache/requirements/";
         private readonly string _cacheFile = "requirements_cache.json";
         private Dictionary<string, CachedRequirements> _cache;
+        private const int MAX_CACHE_ENTRIES = 500;
 
         public RequirementCache()
         {
@@ -60,12 +61,25 @@ namespace AITestAnalyzer
             _cache[cacheKey] = new CachedRequirements
             {
                 DocumentPath = documentPath,
+                CacheKey = cacheKey,
                 DocumentName = Path.GetFileName(documentPath),
                 Requirements = requirements,
                 ExtractedDate = DateTime.Now,
                 TokensUsed = tokensUsed,
                 RequirementCount = requirements.Count
             };
+
+            if (_cache.Count > MAX_CACHE_ENTRIES)
+            {
+                var toRemove = _cache.Values
+                    .OrderBy(c => c.ExtractedDate)
+                    .Take(_cache.Count - MAX_CACHE_ENTRIES)
+                    .Select(c => c.CacheKey)
+                    .ToList();
+
+                foreach (var key in toRemove)
+                    _cache.Remove(key);
+            }
 
             SaveCache();
 
@@ -155,6 +169,7 @@ namespace AITestAnalyzer
     {
         public string DocumentPath { get; set; } = string.Empty;
         public string DocumentName { get; set; } = string.Empty;
+        public string CacheKey { get; set; } = string.Empty;
         public List<ExtractedRequirement> Requirements { get; set; } = new();
         public DateTime ExtractedDate { get; set; }
         public int TokensUsed { get; set; }

--- a/src/AITestAnalyzer/TestCaseCache.cs
+++ b/src/AITestAnalyzer/TestCaseCache.cs
@@ -24,6 +24,7 @@ namespace AITestAnalyzer
         private readonly string _cacheFilePath;
         private Dictionary<string, CachedResult> _cache;
         private const int DEFAULT_MAX_AGE_DAYS = Constants.CACHE_MAX_AGE_DAYS;
+        private const int MAX_CACHE_ENTRIES = 1000;
 
         public TestCaseCache(string cacheDirectory = "cache")
         {
@@ -200,6 +201,20 @@ namespace AITestAnalyzer
                 Tokens = tokens,
                 CachedAt = DateTime.Now
             };
+
+            if (_cache.Count > MAX_CACHE_ENTRIES)
+            {
+                var toRemove = _cache.Values
+                    .OrderBy(c => c.CachedAt)
+                    .Take(_cache.Count - MAX_CACHE_ENTRIES)
+                    .Select(c => c.Hash)
+                    .ToList();
+
+                foreach (var key in toRemove)
+                    _cache.Remove(key);
+            }
+
+            SaveCache();
         }
 
         // Get cache statistics


### PR DESCRIPTION
- TestCaseCache: evicts oldest entries when count > 1000
- RequirementCache: evicts oldest entries when count > 500
- Stored CacheKey directly in CachedRequirements to avoid stale key regeneration on eviction

Closes #21