### PR TITLE
fix(MI-9): Add graceful shutdown handler - cache saved on Ctrl+C

### DIFF
--- a/src/AITestAnalyzer/Batchprocessor .cs
+++ b/src/AITestAnalyzer/Batchprocessor .cs
@@ -346,7 +346,8 @@ namespace AITestAnalyzer
             int? testLimitPerFile = null,
             int worksheetIndex = 0,
             bool useCache = true,
-            string analysisMode = "BA")
+            string analysisMode = "BA",
+            TestCaseCache? externalCache = null)
         {
             var allResults = new List<FileResult>();
             var batchStartTime = DateTime.Now;
@@ -367,8 +368,8 @@ namespace AITestAnalyzer
             string outputDir = ExcelWriter.CreateOutputFolder();
 
             // Initialize shared cache for batch processing
-            TestCaseCache? sharedCache = null;
-            if (useCache)
+            TestCaseCache? sharedCache = externalCache;
+            if (useCache && sharedCache == null)
             {
                 sharedCache = new TestCaseCache();
                 int cacheSize = sharedCache.GetCacheSize();

--- a/src/AITestAnalyzer/Program.cs
+++ b/src/AITestAnalyzer/Program.cs
@@ -21,10 +21,24 @@ namespace AITestAnalyzer
         private const string AppName = "AI Test Suite Analyzer";
         private const int CACHE_MAX_AGE_DAYS = Constants.CACHE_MAX_AGE_DAYS;
 
+        private static TestCaseCache? _activeCache;
+        private static RequirementCache? _activeReqCache;
         static async Task Main(string[] args)
         {
             ExcelPackage.License.SetNonCommercialPersonal("Aravindhan Rajasekaran");
 
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                e.Cancel = true; // Prevent immediate kill
+                Console.WriteLine();
+                WriteWarning("Shutdown requested. Saving cache...");
+
+                _activeCache?.SaveCache();
+                _activeReqCache?.SaveCache();
+
+                WriteSuccess("Cache saved. Exiting cleanly.");
+                Environment.Exit(0);
+            };
             // ============================================================
             // EARLY EXIT FLAGS — these don't need FileSelector at all
             // ============================================================
@@ -310,6 +324,7 @@ namespace AITestAnalyzer
                 WriteInfo("BA MODE: Loading requirements for coverage analysis...");
 
                 var reqCache = new RequirementCache();
+                _activeReqCache = reqCache;
                 var reqExtractor = new RequirementExtractor(appConfig, promptConfig);
 
                 // Auto-detect requirement file
@@ -418,6 +433,7 @@ namespace AITestAnalyzer
             {
                 WriteInfo("Initializing cache system...");
                 cache = new TestCaseCache();
+                _activeCache = cache;
                 int cacheSize = cache.GetCacheSize();
                 int expiredCount = cache.GetExpiredCount(CACHE_MAX_AGE_DAYS);
 
@@ -630,6 +646,9 @@ namespace AITestAnalyzer
 
             // Run batch — pass testLimit as nullable (null = no limit)
             var batchProcessor = new BatchProcessor(appConfig, promptConfig);
+            var sharedCache = new TestCaseCache();
+            _activeCache = sharedCache;
+            _activeReqCache = new RequirementCache();
 
             try
             {
@@ -642,7 +661,8 @@ namespace AITestAnalyzer
                     limitParam,
                     worksheetIndex,
                     useCache,
-                    batchMode);
+                    batchMode,
+                    sharedCache);
 
                 if (results.Count == 0)
                 {

--- a/src/AITestAnalyzer/RequirementCache.cs
+++ b/src/AITestAnalyzer/RequirementCache.cs
@@ -130,7 +130,7 @@ namespace AITestAnalyzer
         /// <summary>
         /// Save cache to disk
         /// </summary>
-        private void SaveCache()
+        public void SaveCache()
         {
             string cachePath = Path.Combine(_cacheFolder, _cacheFile);
 


### PR DESCRIPTION
- Added CancelKeyPress handler in Main() to intercept Ctrl+C
- Static _activeCache and _activeReqCache track active sessions
- Both single and batch modes assign active cache references
- RequirementCache.SaveCache() made public to support handler
- Closes #27